### PR TITLE
Allow multiple --exclude option

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -858,8 +858,16 @@ class PHPCtags
                     continue;
                 }
 
-                if (isset($this->mOptions['exclude']) && false !== strpos($filename, $this->mOptions['exclude'])) {
-                    continue;
+                if (isset($this->mOptions['exclude'])) {
+                    if (is_array($this->mOptions['exclude'])) {
+                        foreach ($this->mOptions['exclude'] as $exclude) {
+                            if ( false !== strpos($filename, $exclude)) {
+                                continue 2;
+                            }
+                        }
+                    } else if ( false !== strpos($filename, $this->mOptions['exclude'])) {
+                        continue;
+                    }
                 }
 
                 try {


### PR DESCRIPTION
`--exclude` option can be multiple.

When there is more than one occurrence of this options, the values are passed in an array in constructor of the PHPCtags class. Then this option value should be treated as an array in `process` method.