### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -663,7 +663,7 @@ class PHPCtags
             if (in_array('s', $this->mOptions['fields']) && !empty($struct['scope'])) {
                 // $scope, $type, $name are current scope variables
                 $scope = array_pop($struct['scope']);
-                list($type, $name) = each($scope);
+                list($type, $name) = [key($scope), current($scope)];
                 switch ($type) {
                     case 'class':
                     case 'interface':
@@ -671,7 +671,7 @@ class PHPCtags
                         // current > class > namespace
                         $n_scope = array_pop($struct['scope']);
                         if(!empty($n_scope)) {
-                            list($n_type, $n_name) = each($n_scope);
+                            list($n_type, $n_name) = [key($n_scope), current($n_scope)];
                             $s_str =  $n_name . '\\' . $name;
                         } else {
                             $s_str =   $name;
@@ -683,10 +683,10 @@ class PHPCtags
                         // c_* stuffs are class related scope variables
                         // current > method > class > namespace
                         $c_scope = array_pop($struct['scope']);
-                        list($c_type, $c_name) = each($c_scope);
+                        list($c_type, $c_name) = [key($c_scope), current($c_scope)];
                         $n_scope = array_pop($struct['scope']);
                         if(!empty($n_scope)) {
-                            list($n_type, $n_name) = each($n_scope);
+                            list($n_type, $n_name) = [key($n_scope), current($n_scope)];
                             $s_str =  $n_name . '\\' . $c_name . '::' . $name;
                         } else {
                             $s_str = $c_name . '::' . $name;
@@ -897,7 +897,7 @@ class PHPCtags
     public  function get_scope( $old_scope) {
         if (!empty($old_scope) ) {
             $scope = array_pop($old_scope);
-            list($type, $name) = each($scope);
+            list($type, $name) = [key($scope), current($scope)];
             switch ($type) {
             case 'class':
             case 'interface':
@@ -906,7 +906,7 @@ class PHPCtags
                 // current > class > namespace
                 $n_scope = array_pop($old_scope);
                 if(!empty($n_scope)) {
-                    list($n_type, $n_name) = each($n_scope);
+                    list($n_type, $n_name) = [key($n_scope), current($n_scope)];
                     $s_str =  '\\'. $n_name . '\\' . $name;
                 } else {
                     $s_str =  '\\' . $name;
@@ -918,10 +918,10 @@ class PHPCtags
                 // c_* stuffs are class related scope variables
                 // current > method > class > namespace
                 $c_scope = array_pop($scope);
-                list($c_type, $c_name) = each($c_scope);
+                list($c_type, $c_name) = [key($c_scope), current($c_scope)];
                 $n_scope = array_pop($scope);
                 if(!empty($n_scope)) {
-                    list($n_type, $n_name) = each($n_scope);
+                    list($n_type, $n_name) = [key($n_scope), current($n_scope)];
                     $s_str =  '\\'. $n_name . '\\' . $c_name . '::' . $name;
                 } else {
                     $s_str = '\\'. $c_name . '::' . $name;


### PR DESCRIPTION
The [`each`](https://www.php.net/manual/en/function.each.php) function has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged.

`*Messages*` buffer:
````
[DEBUG]:  AC-PHP: PHP Stack trace:
[DEBUG]:  AC-PHP: PHP   1. {main}() /.../elpa/ac-php-core-20190329.738/phpctags:0
[DEBUG]:  AC-PHP: PHP   2. include() /.../elpa/ac-php-core-20190329.738/phpctags:10
[DEBUG]:  AC-PHP: PHP   3. deal_config() phar:///.../elpa/ac-php-core-20190329.738/phpctags/bootstrap.php:253
[DEBUG]:  AC-PHP: PHP   4. deal_file_tags() phar:///.../elpa/ac-php-core-20190329.738/phpctags/deal_config.php:335
[DEBUG]:  AC-PHP: PHP   5. PHPCtags->process_single_file() phar:///.../elpa/ac-php-core-20190329.738/phpctags/deal_config.php:237
[DEBUG]:  AC-PHP: PHP   6. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:875
[DEBUG]:  AC-PHP: PHP   7. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:247
[DEBUG]:  AC-PHP: PHP   8. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:516
[DEBUG]:  AC-PHP: PHP   9. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:247
[DEBUG]:  AC-PHP: PHP  10. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:394
[DEBUG]:  AC-PHP: PHP  11. PHPCtags->struct() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:247
[DEBUG]:  AC-PHP: PHP  12. PHPCtags->get_scope() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:571
[DEBUG]:  AC-PHP: PHP  13. each() phar:///.../elpa/ac-php-core-20190329.738/phpctags/PHPCtags.class.php:900
````

<br>

@xcwen Could you please rebuild phpctags