### PR TITLE
Upgrade to PHP-Parser ^5.0.0

### DIFF
--- a/PHPCtags.php
+++ b/PHPCtags.php
@@ -42,7 +42,8 @@ class PHPCtags
 
     public function __construct($options)
     {
-        $this->mParser =  (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        // $this->mParser =  (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $this->mParser =  (new ParserFactory)->createForNewestSupportedVersion();
         $this->mOptions = $options;
         $this->filecount = 0;
     }
@@ -303,7 +304,7 @@ class PHPCtags
             }
         } elseif ($node instanceof \PhpParser\Node\Stmt\TraitUse) {
             foreach ($node ->traits as $trait) {
-                $type= implode("\\", $trait->parts) ;
+                $type= implode("\\", $trait->getParts()) ;
 
                 $name = str_replace("\\", "_", $type) ;
                 $line = $node->getLine();
@@ -343,7 +344,7 @@ class PHPCtags
 
             $doc_item= $node->getDocComment() ;
             if ($doc_item) {
-                $doc_start_line=$doc_item->getLine();
+                $doc_start_line=$doc_item->getStartLine();
                 $arr=explode("\n", ($doc_item->__toString()));
                 foreach ($arr as $line_num => $line_str) {
                     if (preg_match(
@@ -438,7 +439,7 @@ class PHPCtags
                                         // 'file' => $this->mFile,
                                         'kind' => "p",
                                         'name' => $field_name,
-                                        'line' => $comment->getLine() ,
+                                        'line' => $comment->getStartLine() ,
                                         'scope' => $this->get_scope($filed_scope) ,
                                         'access' => "public",
                                         'type' => $field_return_type,

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "require": {
         "php": ">=7.0",
-        "nikic/php-parser": "^4.15"
+        "nikic/php-parser": "^5.0"
     },
     "autoload": {
         "classmap": ["PHPCtags.php"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,35 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7e3e3130f4516a21cc7dc01658b749c",
+    "content-hash": "bbfdeb507faa12962004eb148532444b",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://mirrors.aliyun.com/composer/dists/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -40,7 +36,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -64,20 +60,20 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
In particular I stumbled over this because new Class()->method() (instead of (new Class())->method()) is now legal, but PHP-Parser v4 seemingly did not know.

This patch also switches to use the latest supported PHP-version by default. Perhaps this should be made configurable.